### PR TITLE
feat(attributes): add checksum md5 hash to all blocks

### DIFF
--- a/sops/data_sops_external.go
+++ b/sops/data_sops_external.go
@@ -3,6 +3,7 @@ package sops
 import (
 	"context"
 
+	"github.com/carlpett/terraform-provider-sops/sops/internal/checksum"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -21,6 +22,7 @@ type externalDataSourceModel struct {
 	Source    types.String `tfsdk:"source"`
 	Data      types.Map    `tfsdk:"data"`
 	Raw       types.String `tfsdk:"raw"`
+	Checksum  types.String `tfsdk:"checksum"`
 	Id        types.String `tfsdk:"id"`
 }
 
@@ -56,6 +58,10 @@ func (d *externalDataSource) Schema(_ context.Context, _ datasource.SchemaReques
 				Description: "Unique identifier for this data source",
 				Computed:    true,
 			},
+			"checksum": schema.StringAttribute{
+				Description: "Checksum of the decrypted data (MD5)",
+				Computed:    true,
+			},
 		},
 	}
 }
@@ -88,6 +94,8 @@ func (d *externalDataSource) Read(ctx context.Context, req datasource.ReadReques
 	config.Raw = types.StringValue(raw)
 	config.Id = types.StringValue("-")
 
+	calculatedChecksum := checksum.CalculateMD5(raw)
+	config.Checksum = types.StringValue(calculatedChecksum)
 	diags = resp.State.Set(ctx, config)
 	resp.Diagnostics.Append(diags...)
 }

--- a/sops/data_sops_external_test.go
+++ b/sops/data_sops_external_test.go
@@ -37,6 +37,25 @@ func TestDataSourceSopsExternal(t *testing.T) {
 	})
 }
 
+func TestDataSourceSopsExternal_checksum(t *testing.T) {
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	config := fmt.Sprintf(configTestDataSourceSopsExternal_basic, wd)
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.sops_external.test_basic", "checksum", "a7d251211da07140112e7093dbdb27f0"),
+				),
+			},
+		},
+	})
+}
+
 const configTestDataSourceSopsExternal_nested = `
 data "sops_external" "test_nested" {
   source     = file("%s/test-fixtures/nested.yaml")

--- a/sops/data_sops_file_test.go
+++ b/sops/data_sops_file_test.go
@@ -36,6 +36,25 @@ func TestDataSourceSopsFile_basic(t *testing.T) {
 	})
 }
 
+func TestDataSourceSopsFile_checksum(t *testing.T) {
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	config := fmt.Sprintf(configTestDataSourceSopsFile_basic, wd)
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.sops_file.test_basic", "checksum", "a7d251211da07140112e7093dbdb27f0"),
+				),
+			},
+		},
+	})
+}
+
 const configTestDataSourceSopsFile_nested = `
 data "sops_file" "test_nested" {
   source_file = "%s/test-fixtures/nested.yaml"

--- a/sops/ephemeral_sops_external_test.go
+++ b/sops/ephemeral_sops_external_test.go
@@ -214,3 +214,35 @@ func TestEphemeralSopsExternal_json(t *testing.T) {
 		},
 	})
 }
+
+const configTestEphemeralSopsExternal_checksum = `
+ephemeral "sops_external" "test_json" {
+  source     = file("%s/test-fixtures/basic.json")
+  input_type = "json"
+}
+
+provider "echo" {
+  data = ephemeral.sops_external.test_json.checksum
+}
+
+resource "echo" "checksum" {}
+`
+
+func TestEphemeralSops_checksum(t *testing.T) {
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	config := fmt.Sprintf(configTestEphemeralSopsExternal_checksum, wd)
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("echo.checksum", "data", "66c2c1fea5c50dff338cbf7867259b23"),
+				),
+			},
+		},
+	})
+}

--- a/sops/ephemeral_sops_file_test.go
+++ b/sops/ephemeral_sops_file_test.go
@@ -209,3 +209,34 @@ func TestEphemeralSopsFile_json(t *testing.T) {
 		},
 	})
 }
+
+const configTestEphemeralSopsFile_checksum = `
+ephemeral "sops_file" "test_json" {
+  source_file = "%s/test-fixtures/basic.json"
+}
+
+provider "echo" {
+  data = ephemeral.sops_file.test_json.checksum
+}
+
+resource "echo" "checksum" {}
+`
+
+func TestEphemeralSopsFile_checksum(t *testing.T) {
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	config := fmt.Sprintf(configTestEphemeralSopsFile_checksum, wd)
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("echo.checksum", "data", "66c2c1fea5c50dff338cbf7867259b23"),
+				),
+			},
+		},
+	})
+}

--- a/sops/internal/checksum/calculator.go
+++ b/sops/internal/checksum/calculator.go
@@ -1,0 +1,11 @@
+package checksum
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+)
+
+func CalculateMD5(text string) string {
+	hash := md5.Sum([]byte(text))
+	return hex.EncodeToString(hash[:])
+}

--- a/sops/internal/checksum/calculator_test.go
+++ b/sops/internal/checksum/calculator_test.go
@@ -1,0 +1,33 @@
+package checksum_test
+
+import (
+	"testing"
+
+	"github.com/carlpett/terraform-provider-sops/sops/internal/checksum"
+)
+
+func TestCalculateMD5(t *testing.T) {
+	input := "Some text to calculate md5"
+	expectedMd5 := "f6e1dd4fbcedfe10c7ffb832b961d1d0"
+
+	result := checksum.CalculateMD5(input)
+
+	if result != expectedMd5 {
+		t.Errorf("Expected calculated hash %s, got %s", expectedMd5, result)
+	}
+}
+
+func TestCalculateMD5OnLongString(t *testing.T) {
+	input := `Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod 
+tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam 
+et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum
+dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor 
+invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.`
+	expectedMd5 := "a460956c1299344a6a7cd36111e14e55"
+
+	result := checksum.CalculateMD5(input)
+
+	if result != expectedMd5 {
+		t.Errorf("Expected calculated hash %s, got %s", expectedMd5, result)
+	}
+}


### PR DESCRIPTION
Fixes #54 

This PR calculates the MD5 Hash from the Secret and expose it as "checksum"-Attribute

Im not 100% sure, if it should also be appended to the ephemeral resources

Im also not sure about the package name for the calculator...