### PR TITLE
feat: add env configuration parameter

### DIFF
--- a/docs/data-sources/external.md
+++ b/docs/data-sources/external.md
@@ -36,6 +36,7 @@ output "root-value-hello" {
 
 ### Optional
 
+- `env` (Map of String, Sensitive) Environment variables to set before decrypting
 - `input_type` (String) `yaml`, `json` `dotenv` (`.env`), `ini` or `raw`, depending on the structure of the un-encrypted data.
 
 ### Read-Only

--- a/docs/data-sources/file.md
+++ b/docs/data-sources/file.md
@@ -44,6 +44,7 @@ output "nested-json-value" {
 
 ### Optional
 
+- `env` (Map of String, Sensitive) Environment variables to set before decrypting
 - `input_type` (String) The provider will use the file extension to determine how to unmarshal the data. If your file does not have the usual extension, set this argument to `yaml`, `json`, `dotenv` (`.env`), `ini` accordingly, or `raw` if the encrypted data is encoded differently.
 
 ### Read-Only

--- a/docs/ephemeral-resources/external.md
+++ b/docs/ephemeral-resources/external.md
@@ -36,6 +36,7 @@ output "root_value_hello" {
 
 ### Optional
 
+- `env` (Map of String, Sensitive) Environment variables to set before decrypting
 - `input_type` (String) `yaml`, `json` `dotenv` (`.env`), `ini` or `raw`, depending on the structure of the un-encrypted data.
 
 ### Read-Only

--- a/docs/ephemeral-resources/file.md
+++ b/docs/ephemeral-resources/file.md
@@ -44,6 +44,7 @@ output "nested_json_value" {
 
 ### Optional
 
+- `env` (Map of String, Sensitive) Environment variables to set before decrypting
 - `input_type` (String) The provider will use the file extension to determine how to unmarshal the data. If your file does not have the usual extension, set this argument to `yaml`, `json`, `dotenv` (`.env`), `ini` accordingly, or `raw` if the encrypted data is encoded differently.
 
 ### Read-Only

--- a/sops/data.go
+++ b/sops/data.go
@@ -26,7 +26,7 @@ func newSummaryError(summary string, err error) summaryError {
 	}
 }
 
-func getFileData(sourceFile types.String, inputType types.String) (data map[string]string, raw string, err error) {
+func getFileData(sourceFile types.String, inputType types.String, env types.Map) (data map[string]string, raw string, err error) {
 	sourceFileValue := sourceFile.ValueString()
 	content, err := os.ReadFile(sourceFileValue)
 	if err != nil {
@@ -55,14 +55,14 @@ func getFileData(sourceFile types.String, inputType types.String) (data map[stri
 		return nil, "", newSummaryError("Invalid input type", err)
 	}
 
-	data, raw, err = readData(content, format)
+	data, raw, err = readData(content, format, env)
 	if err != nil {
 		return nil, "", newSummaryError("Error reading data", err)
 	}
 	return data, raw, nil
 }
 
-func getExternalData(source types.String, inputType types.String) (data map[string]string, raw string, err error) {
+func getExternalData(source types.String, inputType types.String, env types.Map) (data map[string]string, raw string, err error) {
 	content, err := io.ReadAll(strings.NewReader(source.ValueString()))
 	if err != nil {
 		return nil, "", newSummaryError("Error reading source", err)
@@ -73,7 +73,7 @@ func getExternalData(source types.String, inputType types.String) (data map[stri
 		return nil, "", newSummaryError("Invalid input type", err)
 	}
 
-	data, raw, err = readData(content, format)
+	data, raw, err = readData(content, format, env)
 	if err != nil {
 		return nil, "", newSummaryError("Error reading data", err)
 	}

--- a/sops/data_sops_external.go
+++ b/sops/data_sops_external.go
@@ -19,6 +19,7 @@ type externalDataSource struct{}
 type externalDataSourceModel struct {
 	InputType types.String `tfsdk:"input_type"`
 	Source    types.String `tfsdk:"source"`
+	Env       types.Map    `tfsdk:"env"`
 	Data      types.Map    `tfsdk:"data"`
 	Raw       types.String `tfsdk:"raw"`
 	Id        types.String `tfsdk:"id"`
@@ -39,6 +40,12 @@ func (d *externalDataSource) Schema(_ context.Context, _ datasource.SchemaReques
 			"source": schema.StringAttribute{
 				Description: "A string with sops-encrypted data",
 				Required:    true,
+			},
+			"env": schema.MapAttribute{
+				Description: "Environment variables to set before decrypting",
+				Optional:    true,
+				Sensitive:   true,
+				ElementType: types.StringType,
 			},
 
 			"data": schema.MapAttribute{
@@ -68,7 +75,7 @@ func (d *externalDataSource) Read(ctx context.Context, req datasource.ReadReques
 		return
 	}
 
-	data, raw, err := getExternalData(config.Source, config.InputType)
+	data, raw, err := getExternalData(config.Source, config.InputType, config.Env)
 	if err != nil {
 		if detailedErr, ok := err.(summaryError); ok {
 			resp.Diagnostics.AddError(detailedErr.Summary, detailedErr.Err.Error())

--- a/sops/data_sops_external_test.go
+++ b/sops/data_sops_external_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 const configTestDataSourceSopsExternal_basic = `
@@ -167,6 +168,88 @@ func TestDataSourceSopsExternal_json(t *testing.T) {
 					resource.TestCheckResourceAttr("data.sops_external.test_json", "data.float", "0.2"),
 					resource.TestCheckResourceAttr("data.sops_external.test_json", "data.bool", "true"),
 					resource.TestCheckResourceAttr("data.sops_external.test_json", "data.null", "null"),
+				),
+			},
+		},
+	})
+}
+
+// age1r6eadvpf2cq967pcgc35ahfkkphqs6ln9frmt6nma52z6tq7zddsszzwrg
+const configTestDataSourceSopsExternal_envAge0 = `
+data "sops_external" "test_env_age0" {
+  source     = file("%s/test-fixtures/basic.age0.yaml")
+  input_type = "yaml"
+  env = {
+    SOPS_AGE_KEY = "AGE-SECRET-KEY-14CSLELDXVWL48V82MSDF8EPVN9KWKKCQ38ZQ80V7Q8ZK7EW26WGQ7W29YP"
+  }
+}`
+
+func TestDataSourceSopsExternal_envAge0(t *testing.T) {
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	config := fmt.Sprintf(configTestDataSourceSopsExternal_envAge0, wd)
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.sops_external.test_env_age0", "data.hello", "world"),
+					resource.TestCheckResourceAttr("data.sops_external.test_env_age0", "data.integer", "0"),
+					resource.TestCheckResourceAttr("data.sops_external.test_env_age0", "data.float", "0.2"),
+					resource.TestCheckResourceAttr("data.sops_external.test_env_age0", "data.bool", "true"),
+					resource.TestCheckResourceAttr("data.sops_external.test_env_age0", "data.null_value", "null"),
+
+					func(s *terraform.State) error {
+						if v := os.Getenv("SOPS_AGE_KEY"); v != "" {
+							return fmt.Errorf("expected SOPS_AGE_KEY unset after data read, got %q", v)
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+// age120rd0a9p49wtru227l4889q6qzcxnlcwrmdgukk94453uzmyqexshcmmzc
+const configTestDataSourceSopsExternal_envAge1 = `
+data "sops_external" "test_env_age1" {
+  source     = file("%s/test-fixtures/basic.age1.yaml")
+  input_type = "yaml"
+  env = {
+    SOPS_AGE_KEY = "AGE-SECRET-KEY-1NERY6H8EQDUTP2WQML30ME8NX89DATTUJC0SJ5RMDZGDL735EJ0SJ8JGRT"
+  }
+}`
+
+func TestDataSourceSopsExternal_envAge1(t *testing.T) {
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	config := fmt.Sprintf(configTestDataSourceSopsExternal_envAge1, wd)
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.sops_external.test_env_age1", "data.hello", "world"),
+					resource.TestCheckResourceAttr("data.sops_external.test_env_age1", "data.integer", "0"),
+					resource.TestCheckResourceAttr("data.sops_external.test_env_age1", "data.float", "0.2"),
+					resource.TestCheckResourceAttr("data.sops_external.test_env_age1", "data.bool", "true"),
+					resource.TestCheckResourceAttr("data.sops_external.test_env_age1", "data.null_value", "null"),
+
+					func(s *terraform.State) error {
+						if v := os.Getenv("SOPS_AGE_KEY"); v != "" {
+							return fmt.Errorf("expected SOPS_AGE_KEY unset after data read, got %q", v)
+						}
+						return nil
+					},
 				),
 			},
 		},

--- a/sops/data_sops_file.go
+++ b/sops/data_sops_file.go
@@ -19,6 +19,7 @@ type fileDataSource struct{}
 type fileDataSourceModel struct {
 	InputType  types.String `tfsdk:"input_type"`
 	SourceFile types.String `tfsdk:"source_file"`
+	Env        types.Map    `tfsdk:"env"`
 	Data       types.Map    `tfsdk:"data"`
 	Raw        types.String `tfsdk:"raw"`
 	Id         types.String `tfsdk:"id"`
@@ -41,6 +42,12 @@ func (d *fileDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, r
 			"source_file": schema.StringAttribute{
 				Description: "Path to the encrypted file.",
 				Required:    true,
+			},
+			"env": schema.MapAttribute{
+				Description: "Environment variables to set before decrypting",
+				Optional:    true,
+				Sensitive:   true,
+				ElementType: types.StringType,
 			},
 
 			"data": schema.MapAttribute{
@@ -70,7 +77,7 @@ func (d *fileDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 		return
 	}
 
-	data, raw, err := getFileData(config.SourceFile, config.InputType)
+	data, raw, err := getFileData(config.SourceFile, config.InputType, config.Env)
 	if err != nil {
 		if detailedErr, ok := err.(summaryError); ok {
 			resp.Diagnostics.AddError(detailedErr.Summary, detailedErr.Err.Error())

--- a/sops/data_sops_file_test.go
+++ b/sops/data_sops_file_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 const configTestDataSourceSopsFile_basic = `
@@ -162,6 +163,86 @@ func TestDataSourceSopsFile_json(t *testing.T) {
 					resource.TestCheckResourceAttr("data.sops_file.test_json", "data.float", "0.2"),
 					resource.TestCheckResourceAttr("data.sops_file.test_json", "data.bool", "true"),
 					resource.TestCheckResourceAttr("data.sops_file.test_json", "data.null", "null"),
+				),
+			},
+		},
+	})
+}
+
+// age1r6eadvpf2cq967pcgc35ahfkkphqs6ln9frmt6nma52z6tq7zddsszzwrg
+const configTestDataSourceSopsFile_envAge0 = `
+data "sops_file" "test_env_age0" {
+  source_file = "%s/test-fixtures/basic.age0.yaml"
+  env = {
+    SOPS_AGE_KEY = "AGE-SECRET-KEY-14CSLELDXVWL48V82MSDF8EPVN9KWKKCQ38ZQ80V7Q8ZK7EW26WGQ7W29YP"
+  }
+}`
+
+func TestDataSourceSopsFile_envAge0(t *testing.T) {
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	config := fmt.Sprintf(configTestDataSourceSopsFile_envAge0, wd)
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.sops_file.test_env_age0", "data.hello", "world"),
+					resource.TestCheckResourceAttr("data.sops_file.test_env_age0", "data.integer", "0"),
+					resource.TestCheckResourceAttr("data.sops_file.test_env_age0", "data.float", "0.2"),
+					resource.TestCheckResourceAttr("data.sops_file.test_env_age0", "data.bool", "true"),
+					resource.TestCheckResourceAttr("data.sops_file.test_env_age0", "data.null_value", "null"),
+
+					func(s *terraform.State) error {
+						if v := os.Getenv("SOPS_AGE_KEY"); v != "" {
+							return fmt.Errorf("expected SOPS_AGE_KEY unset after data read, got %q", v)
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+// age120rd0a9p49wtru227l4889q6qzcxnlcwrmdgukk94453uzmyqexshcmmzc
+const configTestDataSourceSopsFile_envAge1 = `
+data "sops_file" "test_env_age1" {
+  source_file = "%s/test-fixtures/basic.age1.yaml"
+  env = {
+    SOPS_AGE_KEY = "AGE-SECRET-KEY-1NERY6H8EQDUTP2WQML30ME8NX89DATTUJC0SJ5RMDZGDL735EJ0SJ8JGRT"
+  }
+}`
+
+func TestDataSourceSopsFile_envAge1(t *testing.T) {
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	config := fmt.Sprintf(configTestDataSourceSopsFile_envAge1, wd)
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.sops_file.test_env_age1", "data.hello", "world"),
+					resource.TestCheckResourceAttr("data.sops_file.test_env_age1", "data.integer", "0"),
+					resource.TestCheckResourceAttr("data.sops_file.test_env_age1", "data.float", "0.2"),
+					resource.TestCheckResourceAttr("data.sops_file.test_env_age1", "data.bool", "true"),
+					resource.TestCheckResourceAttr("data.sops_file.test_env_age1", "data.null_value", "null"),
+
+					func(s *terraform.State) error {
+						if v := os.Getenv("SOPS_AGE_KEY"); v != "" {
+							return fmt.Errorf("expected SOPS_AGE_KEY unset after data read, got %q", v)
+						}
+						return nil
+					},
 				),
 			},
 		},

--- a/sops/ephemeral_sops_external.go
+++ b/sops/ephemeral_sops_external.go
@@ -19,6 +19,7 @@ type externalEphemeralResource struct{}
 type externalEphemeralModel struct {
 	InputType types.String `tfsdk:"input_type"`
 	Source    types.String `tfsdk:"source"`
+	Env       types.Map    `tfsdk:"env"`
 	Data      types.Map    `tfsdk:"data"`
 	Raw       types.String `tfsdk:"raw"`
 }
@@ -38,6 +39,12 @@ func (d *externalEphemeralResource) Schema(_ context.Context, _ ephemeral.Schema
 			"source": schema.StringAttribute{
 				Description: "A string with sops-encrypted data",
 				Required:    true,
+			},
+			"env": schema.MapAttribute{
+				Description: "Environment variables to set before decrypting",
+				Optional:    true,
+				Sensitive:   true,
+				ElementType: types.StringType,
 			},
 
 			"data": schema.MapAttribute{
@@ -63,7 +70,7 @@ func (d *externalEphemeralResource) Open(ctx context.Context, req ephemeral.Open
 		return
 	}
 
-	data, raw, err := getExternalData(config.Source, config.InputType)
+	data, raw, err := getExternalData(config.Source, config.InputType, config.Env)
 	if err != nil {
 		if detailedErr, ok := err.(summaryError); ok {
 			resp.Diagnostics.AddError(detailedErr.Summary, detailedErr.Err.Error())

--- a/sops/ephemeral_sops_external_test.go
+++ b/sops/ephemeral_sops_external_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 const configTestEphemeralSopsExternal_basic = `
@@ -209,6 +210,102 @@ func TestEphemeralSopsExternal_json(t *testing.T) {
 					resource.TestCheckResourceAttr("echo.test_json", "data.float", "0.2"),
 					resource.TestCheckResourceAttr("echo.test_json", "data.bool", "true"),
 					resource.TestCheckResourceAttr("echo.test_json", "data.null", "null"),
+				),
+			},
+		},
+	})
+}
+
+// age1r6eadvpf2cq967pcgc35ahfkkphqs6ln9frmt6nma52z6tq7zddsszzwrg
+const configTestEphemeralSopsExternal_envAge0 = `
+ephemeral "sops_external" "test_env_age0" {
+  source     = file("%s/test-fixtures/basic.age0.yaml")
+  input_type = "yaml"
+  env = {
+    SOPS_AGE_KEY = "AGE-SECRET-KEY-14CSLELDXVWL48V82MSDF8EPVN9KWKKCQ38ZQ80V7Q8ZK7EW26WGQ7W29YP"
+  }
+}
+
+provider "echo" {
+  data = ephemeral.sops_external.test_env_age0.data
+}
+
+resource "echo" "test_env_age0" {}
+`
+
+func TestEphemeralSopsExternal_envAge0(t *testing.T) {
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	config := fmt.Sprintf(configTestEphemeralSopsExternal_envAge0, wd)
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("echo.test_env_age0", "data.hello", "world"),
+					resource.TestCheckResourceAttr("echo.test_env_age0", "data.integer", "0"),
+					resource.TestCheckResourceAttr("echo.test_env_age0", "data.float", "0.2"),
+					resource.TestCheckResourceAttr("echo.test_env_age0", "data.bool", "true"),
+					resource.TestCheckResourceAttr("echo.test_env_age0", "data.null_value", "null"),
+
+					func(s *terraform.State) error {
+						if v := os.Getenv("SOPS_AGE_KEY"); v != "" {
+							return fmt.Errorf("expected SOPS_AGE_KEY unset after data read, got %q", v)
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+// age120rd0a9p49wtru227l4889q6qzcxnlcwrmdgukk94453uzmyqexshcmmzc
+const configTestEphemeralSopsExternal_envAge1 = `
+ephemeral "sops_external" "test_env_age1" {
+  source     = file("%s/test-fixtures/basic.age1.yaml")
+  input_type = "yaml"
+  env = {
+    SOPS_AGE_KEY = "AGE-SECRET-KEY-1NERY6H8EQDUTP2WQML30ME8NX89DATTUJC0SJ5RMDZGDL735EJ0SJ8JGRT"
+  }
+}
+
+provider "echo" {
+  data = ephemeral.sops_external.test_env_age1.data
+}
+
+resource "echo" "test_env_age1" {}
+`
+
+func TestEphemeralSopsExternal_envAge1(t *testing.T) {
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	config := fmt.Sprintf(configTestEphemeralSopsExternal_envAge1, wd)
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("echo.test_env_age1", "data.hello", "world"),
+					resource.TestCheckResourceAttr("echo.test_env_age1", "data.integer", "0"),
+					resource.TestCheckResourceAttr("echo.test_env_age1", "data.float", "0.2"),
+					resource.TestCheckResourceAttr("echo.test_env_age1", "data.bool", "true"),
+					resource.TestCheckResourceAttr("echo.test_env_age1", "data.null_value", "null"),
+
+					func(s *terraform.State) error {
+						if v := os.Getenv("SOPS_AGE_KEY"); v != "" {
+							return fmt.Errorf("expected SOPS_AGE_KEY unset after data read, got %q", v)
+						}
+						return nil
+					},
 				),
 			},
 		},

--- a/sops/ephemeral_sops_file.go
+++ b/sops/ephemeral_sops_file.go
@@ -19,6 +19,7 @@ type fileEphemeralResource struct{}
 type fileEphemeralResourceModel struct {
 	InputType  types.String `tfsdk:"input_type"`
 	SourceFile types.String `tfsdk:"source_file"`
+	Env        types.Map    `tfsdk:"env"`
 	Data       types.Map    `tfsdk:"data"`
 	Raw        types.String `tfsdk:"raw"`
 }
@@ -40,6 +41,12 @@ func (d *fileEphemeralResource) Schema(_ context.Context, _ ephemeral.SchemaRequ
 			"source_file": schema.StringAttribute{
 				Description: "Path to the encrypted file",
 				Required:    true,
+			},
+			"env": schema.MapAttribute{
+				Description: "Environment variables to set before decrypting",
+				Optional:    true,
+				Sensitive:   true,
+				ElementType: types.StringType,
 			},
 
 			"data": schema.MapAttribute{
@@ -65,7 +72,7 @@ func (d *fileEphemeralResource) Open(ctx context.Context, req ephemeral.OpenRequ
 		return
 	}
 
-	data, raw, err := getFileData(config.SourceFile, config.InputType)
+	data, raw, err := getFileData(config.SourceFile, config.InputType, config.Env)
 	if err != nil {
 		if detailedErr, ok := err.(summaryError); ok {
 			resp.Diagnostics.AddError(detailedErr.Summary, detailedErr.Err.Error())

--- a/sops/ephemeral_sops_file_test.go
+++ b/sops/ephemeral_sops_file_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 const configTestEphemeralSopsFile_basic = `
@@ -204,6 +205,100 @@ func TestEphemeralSopsFile_json(t *testing.T) {
 					resource.TestCheckResourceAttr("echo.test_json", "data.float", "0.2"),
 					resource.TestCheckResourceAttr("echo.test_json", "data.bool", "true"),
 					resource.TestCheckResourceAttr("echo.test_json", "data.null", "null"),
+				),
+			},
+		},
+	})
+}
+
+// age1r6eadvpf2cq967pcgc35ahfkkphqs6ln9frmt6nma52z6tq7zddsszzwrg
+const configTestEphemeralSopsFile_envAge0 = `
+ephemeral "sops_file" "test_env_age0" {
+  source_file = "%s/test-fixtures/basic.age0.yaml"
+  env = {
+    SOPS_AGE_KEY = "AGE-SECRET-KEY-14CSLELDXVWL48V82MSDF8EPVN9KWKKCQ38ZQ80V7Q8ZK7EW26WGQ7W29YP"
+  }
+}
+
+provider "echo" {
+  data = ephemeral.sops_file.test_env_age0.data
+}
+
+resource "echo" "test_env_age0" {}
+`
+
+func TestEphemeralSopsFile_envAge0(t *testing.T) {
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	config := fmt.Sprintf(configTestEphemeralSopsFile_envAge0, wd)
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("echo.test_env_age0", "data.hello", "world"),
+					resource.TestCheckResourceAttr("echo.test_env_age0", "data.integer", "0"),
+					resource.TestCheckResourceAttr("echo.test_env_age0", "data.float", "0.2"),
+					resource.TestCheckResourceAttr("echo.test_env_age0", "data.bool", "true"),
+					resource.TestCheckResourceAttr("echo.test_env_age0", "data.null_value", "null"),
+
+					func(s *terraform.State) error {
+						if v := os.Getenv("SOPS_AGE_KEY"); v != "" {
+							return fmt.Errorf("expected SOPS_AGE_KEY unset after data read, got %q", v)
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+// age120rd0a9p49wtru227l4889q6qzcxnlcwrmdgukk94453uzmyqexshcmmzc
+const configTestEphemeralSopsFile_envAge1 = `
+ephemeral "sops_file" "test_env_age1" {
+  source_file = "%s/test-fixtures/basic.age1.yaml"
+  env = {
+    SOPS_AGE_KEY = "AGE-SECRET-KEY-1NERY6H8EQDUTP2WQML30ME8NX89DATTUJC0SJ5RMDZGDL735EJ0SJ8JGRT"
+  }
+}
+
+provider "echo" {
+  data = ephemeral.sops_file.test_env_age1.data
+}
+
+resource "echo" "test_env_age1" {}
+`
+
+func TestEphemeralSopsFile_envAge1(t *testing.T) {
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	config := fmt.Sprintf(configTestEphemeralSopsFile_envAge1, wd)
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("echo.test_env_age1", "data.hello", "world"),
+					resource.TestCheckResourceAttr("echo.test_env_age1", "data.integer", "0"),
+					resource.TestCheckResourceAttr("echo.test_env_age1", "data.float", "0.2"),
+					resource.TestCheckResourceAttr("echo.test_env_age1", "data.bool", "true"),
+					resource.TestCheckResourceAttr("echo.test_env_age1", "data.null_value", "null"),
+
+					func(s *terraform.State) error {
+						if v := os.Getenv("SOPS_AGE_KEY"); v != "" {
+							return fmt.Errorf("expected SOPS_AGE_KEY unset after data read, got %q", v)
+						}
+						return nil
+					},
 				),
 			},
 		},

--- a/sops/read_data.go
+++ b/sops/read_data.go
@@ -3,16 +3,47 @@ package sops
 import (
 	"encoding/json"
 	"fmt"
+	"os"
+	"sync"
 
 	"github.com/getsops/sops/v3"
 	"github.com/getsops/sops/v3/decrypt"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"gopkg.in/yaml.v3"
 
 	"github.com/carlpett/terraform-provider-sops/sops/internal/dotenv"
 	"github.com/carlpett/terraform-provider-sops/sops/internal/ini"
 )
 
-func readData(content []byte, format string) (map[string]string, string, error) {
+var decryptMutex sync.Mutex
+
+func readData(content []byte, format string, env types.Map) (map[string]string, string, error) {
+
+	if !env.IsNull() && !env.IsUnknown() {
+		rawMap := env.Elements()
+		envMap := make(map[string]string, len(rawMap))
+		for k, v := range rawMap {
+			if vStr, ok := v.(types.String); ok && !vStr.IsNull() && !vStr.IsUnknown() {
+				envMap[k] = vStr.ValueString()
+			}
+		}
+
+		decryptMutex.Lock()
+		defer decryptMutex.Unlock()
+
+		for k, v := range envMap {
+			if err := os.Setenv(k, v); err != nil {
+				return nil, "", fmt.Errorf("failed to set environment variable %q: %w", k, err)
+			}
+		}
+
+		defer func() {
+			for k := range envMap {
+				_ = os.Unsetenv(k)
+			}
+		}()
+	}
+
 	cleartext, err := decrypt.Data(content, format)
 	if userErr, ok := err.(sops.UserError); ok {
 		err = userErr

--- a/sops/test-fixtures/.sops.yaml
+++ b/sops/test-fixtures/.sops.yaml
@@ -1,0 +1,7 @@
+creation_rules:
+  - path_regex: basic.age0.yaml
+    age: >-
+      age1r6eadvpf2cq967pcgc35ahfkkphqs6ln9frmt6nma52z6tq7zddsszzwrg
+  - path_regex: basic.age1.yaml
+    age: >-
+      age120rd0a9p49wtru227l4889q6qzcxnlcwrmdgukk94453uzmyqexshcmmzc

--- a/sops/test-fixtures/basic.age0.yaml
+++ b/sops/test-fixtures/basic.age0.yaml
@@ -1,0 +1,20 @@
+hello: ENC[AES256_GCM,data:gzR9Gz4=,iv:cbMZU1nUyo5mFCW+Vel2UYbnbMA/0wKxsQzy/WVAYw8=,tag:tETDJMCJYo+4K4LwsSw4Dw==,type:str]
+integer: ENC[AES256_GCM,data:9w==,iv:8gMmdZTOgdGdHlXvipvz4qchxFWMwKg95Zzvh/I84G4=,tag:jxzxI0m7stEK+zr+yc0Wsg==,type:int]
+float: ENC[AES256_GCM,data:UtBf,iv:Z7hdgplz8QP9JyC/DX5WWiazdYjBvZTVolvyf9VNvyw=,tag:v8VujtMTcuM4GuZKGreVbA==,type:float]
+bool: ENC[AES256_GCM,data:xW/sRw==,iv:0vXeg5/SBUDo8dmHHpDTdxMwpoCdx+ERE7dq4UgqVsc=,tag:RweVRArPBVskGtnPBiQ0Yg==,type:bool]
+null_value: null
+sops:
+    age:
+        - recipient: age1r6eadvpf2cq967pcgc35ahfkkphqs6ln9frmt6nma52z6tq7zddsszzwrg
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB1VjlGNUJMekU2NzZiSWhW
+            N0t1S0owQjNQM2syTnZ2bXFWTDBkdXVaNkdJCjN5KzU3Y2h6MGVEakh5WWtHOGVP
+            NnNYNENXV1dpanZkY0ZQazVvUmluVEkKLS0tIDZQZTRRZGU0NzhDc0ZBMVpsK2Vq
+            azJhRWZwMG1KcWxJK0VCcEs3YWdNcjAKTeJqXBVUSfCT7C7vcr6VvARbF8AwWqFQ
+            7chZmK2iuzh4ZQDroqe8Wr1aCk1Qmh/gxnxQFBsL8SSFJJpd5a1d9g==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2019-04-26T18:43:59Z"
+    mac: ENC[AES256_GCM,data:UdHBCIrxfP+FjXwi0++Y1MUdAZ3hAa34OfG/w911zimF2YR+Mqv7PD15Osqa9GotQ5idzJEAzvz6pRVm7J388s0g2E53zBjCfLO/dcrkmVRdjTw2WYM17ewGM61HlNB9EKPe38B/eTH6PP1pTs5vjplEM/3FDblglKw8koUDdp0=,iv:LmRycuJjAoyGaY8qazR6G5CEuyD8JYCe3OO9UTek6kE=,tag:pfpB4HNE1qVmhO1QdZvVkQ==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.2.0

--- a/sops/test-fixtures/basic.age1.yaml
+++ b/sops/test-fixtures/basic.age1.yaml
@@ -1,0 +1,20 @@
+hello: ENC[AES256_GCM,data:gzR9Gz4=,iv:cbMZU1nUyo5mFCW+Vel2UYbnbMA/0wKxsQzy/WVAYw8=,tag:tETDJMCJYo+4K4LwsSw4Dw==,type:str]
+integer: ENC[AES256_GCM,data:9w==,iv:8gMmdZTOgdGdHlXvipvz4qchxFWMwKg95Zzvh/I84G4=,tag:jxzxI0m7stEK+zr+yc0Wsg==,type:int]
+float: ENC[AES256_GCM,data:UtBf,iv:Z7hdgplz8QP9JyC/DX5WWiazdYjBvZTVolvyf9VNvyw=,tag:v8VujtMTcuM4GuZKGreVbA==,type:float]
+bool: ENC[AES256_GCM,data:xW/sRw==,iv:0vXeg5/SBUDo8dmHHpDTdxMwpoCdx+ERE7dq4UgqVsc=,tag:RweVRArPBVskGtnPBiQ0Yg==,type:bool]
+null_value: null
+sops:
+    age:
+        - recipient: age120rd0a9p49wtru227l4889q6qzcxnlcwrmdgukk94453uzmyqexshcmmzc
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBqL0hHZ2drVUl5b0RySzJn
+            eTR4RzE0alJPekRjUnZOcnp3SVFvem9Gcnh3Ck1KTENPNVYwY0xLcE9EM3M0amFp
+            YVE0N3AyeXF3eUFIREpqckZNNnZNTE0KLS0tIFAvcnV6ZzhvVS93L3N6M0ozZFhs
+            STVKeFphdVhkdE9HQ2lDaGtQckdIYUEKfgFRHpHMjVmuJfIyNBVU+ArkpBm/11Pw
+            7nAGHBuf4FjExlUEi0RlRTnHw51HMmlobUP0mtx21Ndmvwzce1fshA==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2019-04-26T18:43:59Z"
+    mac: ENC[AES256_GCM,data:UdHBCIrxfP+FjXwi0++Y1MUdAZ3hAa34OfG/w911zimF2YR+Mqv7PD15Osqa9GotQ5idzJEAzvz6pRVm7J388s0g2E53zBjCfLO/dcrkmVRdjTw2WYM17ewGM61HlNB9EKPe38B/eTH6PP1pTs5vjplEM/3FDblglKw8koUDdp0=,iv:LmRycuJjAoyGaY8qazR6G5CEuyD8JYCe3OO9UTek6kE=,tag:pfpB4HNE1qVmhO1QdZvVkQ==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.2.0


### PR DESCRIPTION
### Summary

This PR implements support for passing **environment variables** to the process before invoking the **SOPS** library.

It’s conceptually similar to the following PRs:

- [https://github.com/carlpett/terraform-provider-sops/pull/121](https://github.com/carlpett/terraform-provider-sops/pull/121)
- [https://github.com/carlpett/terraform-provider-sops/pull/143](https://github.com/carlpett/terraform-provider-sops/pull/143)

However, in this implementation, environment variables are injected **at the resource level**, not globally at the provider level.
(Technically, both approaches can coexist if needed.)

---

### Motivation

This design resolves several limitations and edge cases related to using environment variables only within the `provider` block — especially when dynamic or per-resource secret configuration is required.

A detailed explanation, along with working examples, can be found here:

- [https://github.com/binlab/examples-provider-sops](https://github.com/binlab/examples-provider-sops)

---

### Testing

The examples include complete tests that demonstrate real-world usage, including dynamic variable passing and decryption behavior validation.